### PR TITLE
feat: Add extra for laravel auto discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,12 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "NotificationChannels\\Smsapi\\SmsapiServiceProvider"
+            ]
+        }
     }
 }


### PR DESCRIPTION
In https://github.com/laravel-notification-channels/smsapi/pull/8 documentation on registering the ServiceProvider was removed. But auto discovery was missing the required infos in composer.json.