### PR TITLE
feat: add config for switching apis tld

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ php artisan vendor:publish --provider="NotificationChannels\Smsapi\SmsapiService
 
 ### Setting up the Smsapi service
 
-Log in to your [Smsapi dashboard](https://ssl.smsapi.pl/) and configure your preferred authentication method.
+Log in to your Smsapi dashboard and configure your preferred authentication method. There is a
+[polish version](https://ssl.smsapi.pl/) and an [international version](https://ssl.smsapi.com/)
+which have separated accounts.
 Set your credentials and defaults in `config/smsapi.php`:
 
 ```php
@@ -53,6 +55,8 @@ Set your credentials and defaults in `config/smsapi.php`:
         // 'username' => env('SMSAPI_AUTH_USERNAME'),
         // 'password' => env('SMSAPI_AUTH_PASSWORD'), // Hashed by MD5
     ],
+    // TLD of smsapi. Can be PL or COM.
+    'service_domain' => 'PL',
 ],
 'defaults' => [
     'common' => [

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Set your credentials and defaults in `config/smsapi.php`:
         // 'username' => env('SMSAPI_AUTH_USERNAME'),
         // 'password' => env('SMSAPI_AUTH_PASSWORD'), // Hashed by MD5
     ],
-    // TLD of smsapi. Can be PL or COM.
-    'service_domain' => 'PL',
+    // Service of smsapi. Can be SmsapiClient::SERVICE_PL or SmsapiClient::SERVICE_COM.
+    'service' => SmsapiClient::SERVICE_PL,
 ],
 'defaults' => [
     'common' => [

--- a/config/smsapi.php
+++ b/config/smsapi.php
@@ -1,5 +1,7 @@
 <?php
 
+use NotificationChannels\Smsapi\SmsapiClient;
+
 return [
     'auth' => [
         /*
@@ -21,15 +23,15 @@ return [
 
         /*
         |----------------------------------------------------------------------
-        | TLD of services domain
+        | SMSAPI service type
         |----------------------------------------------------------------------
         | SMSAPI runs a polish service on smsapi.pl and a international service
         | on smsapi.com. This option will set which version will be used.
         |
-        | Supported: "PL", "COM".
+        | Supported: "SmsapiClient::SERVICE_PL", "SmsapiClient::SERVICE_COM".
         |
         */
-        'service_domain' => 'PL',
+        'service' => SmsapiClient::SERVICE_PL,
     ],
 
     /*

--- a/config/smsapi.php
+++ b/config/smsapi.php
@@ -18,6 +18,18 @@ return [
             // 'username' => env('SMSAPI_AUTH_USERNAME'),
             // 'password' => env('SMSAPI_AUTH_PASSWORD'), // Hashed by MD5
         ],
+
+        /*
+        |----------------------------------------------------------------------
+        | TLD of services domain
+        |----------------------------------------------------------------------
+        | SMSAPI runs a polish service on smsapi.pl and a international service
+        | on smsapi.com. This option will set which version will be used.
+        |
+        | Supported: "PL", "COM".
+        |
+        */
+        'service_domain' => 'PL',
     ],
 
     /*

--- a/src/SmsapiClient.php
+++ b/src/SmsapiClient.php
@@ -26,6 +26,11 @@ class SmsapiClient
      */
     protected $proxy;
 
+    public const SERVICE_PL = 'https://api.smsapi.pl';
+
+    public const SERVICE_COM = 'https://api.smsapi.com';
+
+
     /**
      * @param Client     $client
      * @param array      $defaults

--- a/src/SmsapiClient.php
+++ b/src/SmsapiClient.php
@@ -30,7 +30,6 @@ class SmsapiClient
 
     public const SERVICE_COM = 'https://api.smsapi.com';
 
-
     /**
      * @param Client     $client
      * @param array      $defaults

--- a/src/SmsapiServiceProvider.php
+++ b/src/SmsapiServiceProvider.php
@@ -17,7 +17,7 @@ class SmsapiServiceProvider extends ServiceProvider
             ->needs(SmsapiClient::class)
             ->give(function () {
                 $config = config('smsapi');
-                $auth = $config['auth'] + ['service_domain' => 'PL'];
+                $auth = $config['auth'] + ['service' => SmsapiClient::SERVICE_PL];
                 if ($auth['method'] === 'token') {
                     $client = Client::createFromToken($auth['credentials']['token']);
                 } elseif ($auth['method'] === 'password') {
@@ -45,10 +45,7 @@ class SmsapiServiceProvider extends ServiceProvider
                     });
                 }, $defaults);
 
-                $proxy = strtoupper($auth['service_domain']) == 'COM'
-                    ? new Native('https://api.smsapi.com')
-                    : new Native('https://api.smsapi.pl');
-
+                $proxy = new Native($auth['service']);
                 return new SmsapiClient($client, $defaults, $proxy);
             });
 

--- a/src/SmsapiServiceProvider.php
+++ b/src/SmsapiServiceProvider.php
@@ -46,6 +46,7 @@ class SmsapiServiceProvider extends ServiceProvider
                 }, $defaults);
 
                 $proxy = new Native($auth['service']);
+
                 return new SmsapiClient($client, $defaults, $proxy);
             });
 


### PR DESCRIPTION
This PR adds the support for the international version "smsapi.com" of the service. Which version should be used can be selected via a config option. 