### PR TITLE
fix: handling of default values

### DIFF
--- a/src/SmsapiClient.php
+++ b/src/SmsapiClient.php
@@ -59,7 +59,8 @@ class SmsapiClient
      */
     public function sendSms(SmsapiSmsMessage $message)
     {
-        $data = $message->data + $this->defaults;
+        $data = $this->mergeDefaults($message->data, 'sms');
+
         $sms = (new SmsFactory($this->proxy, $this->client))->actionSend();
         if (isset($data['content'])) {
             $sms->setText($data['content']);
@@ -116,7 +117,8 @@ class SmsapiClient
      */
     public function sendMms(SmsapiMmsMessage $message)
     {
-        $data = $message->data + $this->defaults;
+        $data = $this->mergeDefaults($message->data, 'mms');
+
         $mms = (new MmsFactory($this->proxy, $this->client))->actionSend();
         $mms->setSubject($data['subject']);
         $mms->setSmil($data['smil']);
@@ -148,7 +150,8 @@ class SmsapiClient
      */
     public function sendVms(SmsapiVmsMessage $message)
     {
-        $data = $message->data + $this->defaults;
+        $data = $this->mergeDefaults($message->data, 'vms');
+
         $vms = (new VmsFactory($this->proxy, $this->client))->actionSend();
         if (isset($data['file'])) {
             $vms->setFile($data['file']);
@@ -188,5 +191,21 @@ class SmsapiClient
         }
 
         return $vms->execute();
+    }
+
+    /**
+     * Merge defaults into message data
+     *
+     * @param array $data message data
+     * @param string $type sms, mms, vms
+     * @return array defaults merged with message data
+     */
+    private function mergeDefaults(array $data, string $type)
+    {
+        if (array_key_exists($type, $this->defaults)) {
+            $data += $this->defaults['sms'];
+        }
+
+        return $data;
     }
 }

--- a/src/SmsapiClient.php
+++ b/src/SmsapiClient.php
@@ -194,7 +194,7 @@ class SmsapiClient
     }
 
     /**
-     * Merge defaults into message data
+     * Merge defaults into message data.
      *
      * @param array $data message data
      * @param string $type sms, mms, vms

--- a/src/SmsapiServiceProvider.php
+++ b/src/SmsapiServiceProvider.php
@@ -25,19 +25,28 @@ class SmsapiServiceProvider extends ServiceProvider
                     $client->setPasswordHash($auth['credentials']['password']);
                 }
                 $defaults = $config['defaults'] + ['sms' => [], 'mms' => [], 'vms' => []];
+
+                $defaults['sms'] = Arr::only($defaults['sms'], [
+                    'from', 'fast', 'flash', 'encoding', 'normalize', 'nounicode', 'single',
+                ]);
+
+                $defaults['mms'] = Arr::only($defaults['mms'], [
+                ]);
+
+                $defaults['vms'] = Arr::only($defaults['vms'], [
+                    'from', 'tries', 'interval', 'tts_lector', 'skip_gsm',
+                ]);
+
                 if (! empty($defaults['common'])) {
                     $defaults['common'] = Arr::only($defaults['common'], [
                         'notify_url', 'partner', 'test',
                     ]);
-                    $defaults['sms'] = Arr::only($defaults['sms'] + $defaults['common'], [
-                        'from', 'fast', 'flash', 'encoding', 'normalize', 'nounicode', 'single',
-                    ]);
-                    $defaults['mms'] = Arr::only($defaults['mms'] + $defaults['common'], [
-                    ]);
-                    $defaults['vms'] = Arr::only($defaults['vms'] + $defaults['common'], [
-                        'from', 'tries', 'interval', 'tts_lector', 'skip_gsm',
-                    ]);
+
+                    $defaults['sms'] += $defaults['common'];
+                    $defaults['mms'] += $defaults['common'];
+                    $defaults['vms'] += $defaults['common'];
                 }
+
                 $defaults = Arr::only($defaults, ['sms', 'mms', 'vms']);
                 $defaults = array_map(function (array $defaults) {
                     return array_filter($defaults, function ($value) {


### PR DESCRIPTION
SMS, MMS and VMS defaults were only validated when common was not empty.
Common values had no effect since they were removed immediately by array_only after merging.

This is a duplicate of https://github.com/laravel-notification-channels/smsapi/pull/14. I messed up my branch by accidentally force pushing the resetted branch 🤦‍♂️