### PR TITLE
Fix implicitly marking parameter $proxy as nullable

### DIFF
--- a/src/SmsapiClient.php
+++ b/src/SmsapiClient.php
@@ -35,7 +35,7 @@ class SmsapiClient
      * @param array      $defaults
      * @param Proxy|null $proxy
      */
-    public function __construct(Client $client, array $defaults = [], Proxy $proxy = null)
+    public function __construct(Client $client, array $defaults = [], ?Proxy $proxy = null)
     {
         $this->client = $client;
         $this->defaults = $defaults;


### PR DESCRIPTION
Deprecated: NotificationChannels\Smsapi\SmsapiClient::__construct(): Implicitly marking parameter $proxy as nullable is deprecated, the explicit nullable type must be used instead